### PR TITLE
Use boxed types in A* data structures.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 /tsa_config
 /*.log
+/callgrind.out.*

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,6 @@ compact-genome = "12.3.0"
 traitsequence = "8.1.2"
 log = "0.4.27"
 num-traits = "0.2.19"
+
+[profile.release]
+debug = true

--- a/generic_a_star/src/lib.rs
+++ b/generic_a_star/src/lib.rs
@@ -579,3 +579,31 @@ impl<NodeIdentifier, Cost> Default for AStarResult<NodeIdentifier, Cost> {
         Self::NoTarget
     }
 }
+
+impl<T: AStarNode> AStarNode for Box<T> {
+    type Identifier = <T as AStarNode>::Identifier;
+
+    type EdgeType = <T as AStarNode>::EdgeType;
+
+    type Cost = <T as AStarNode>::Cost;
+
+    fn identifier(&self) -> &Self::Identifier {
+        <T as AStarNode>::identifier(self)
+    }
+
+    fn cost(&self) -> Self::Cost {
+        <T as AStarNode>::cost(self)
+    }
+
+    fn a_star_lower_bound(&self) -> Self::Cost {
+        <T as AStarNode>::a_star_lower_bound(self)
+    }
+
+    fn predecessor(&self) -> Option<&Self::Identifier> {
+        <T as AStarNode>::predecessor(self)
+    }
+
+    fn predecessor_edge_type(&self) -> Option<Self::EdgeType> {
+        <T as AStarNode>::predecessor_edge_type(self)
+    }
+}

--- a/lib_tsalign/src/a_star_aligner/template_switch_distance/lower_bounds/template_switch.rs
+++ b/lib_tsalign/src/a_star_aligner/template_switch_distance/lower_bounds/template_switch.rs
@@ -105,7 +105,7 @@ impl<Cost: AStarCost> TemplateSwitchLowerBoundMatrix<Cost> {
                 ),
             );
             let root_xy = genome_length / 2;
-            a_star.initialise_with(|context| Node::new_root_at(root_xy, root_xy, context));
+            a_star.initialise_with(|context| Node::new_root_at(root_xy, root_xy, context).into());
             previous_closed_lower_bounds.extend(closed_lower_bounds.drain());
 
             let root_xy_isize = isize::try_from(root_xy).unwrap();

--- a/lib_tsalign/src/a_star_aligner/template_switch_distance/strategies/shortcut.rs
+++ b/lib_tsalign/src/a_star_aligner/template_switch_distance/strategies/shortcut.rs
@@ -88,14 +88,21 @@ impl<Cost: AStarCost> ShortcutStrategy<Cost> for TemplateSwitchLowerBoundShortcu
             Identifier::Primary { flank_index, .. }
             | Identifier::PrimaryReentry { flank_index, .. } => {
                 if flank_index == context.config.left_flank_length {
-                    opened_nodes_output.extend(context.memory.shortcut.iter().flat_map(|entry| {
-                        node.generate_template_switch_shortcut_successor(
-                            entry.x(),
-                            entry.y(),
-                            entry.cost(),
-                            context,
-                        )
-                    }));
+                    opened_nodes_output.extend(
+                        context
+                            .memory
+                            .shortcut
+                            .iter()
+                            .flat_map(|entry| {
+                                node.generate_template_switch_shortcut_successor(
+                                    entry.x(),
+                                    entry.y(),
+                                    entry.cost(),
+                                    context,
+                                )
+                            })
+                            .map(Into::into),
+                    );
                 }
             }
 

--- a/lib_tsalign/src/a_star_aligner/template_switch_distance/strategies/template_switch_min_length.rs
+++ b/lib_tsalign/src/a_star_aligner/template_switch_distance/strategies/template_switch_min_length.rs
@@ -241,10 +241,10 @@ impl<
     Strategies: AlignmentStrategySelector,
 > AStarContext for TemplateSwitchMinLengthContext<'_, '_, '_, SubsequenceType, Strategies>
 {
-    type Node = Node<Strategies>;
+    type Node = Box<Node<Strategies>>;
 
     fn create_root(&self) -> Self::Node {
-        self.root_node.clone()
+        self.root_node.clone().into()
     }
 
     fn generate_successors(&mut self, node: &Self::Node, output: &mut impl Extend<Self::Node>) {


### PR DESCRIPTION
End result is that this does not reduce runtime, but rather memory, but we take it.