### PR TITLE
feat: add flag to disable extending the alignment range

### DIFF
--- a/lib_tsalign/src/a_star_aligner.rs
+++ b/lib_tsalign/src/a_star_aligner.rs
@@ -181,7 +181,7 @@ pub fn template_switch_distance_a_star_align<
     query: &SubsequenceType,
     reference_name: &str,
     query_name: &str,
-    range: AlignmentRange,
+    mut range: AlignmentRange,
     config: &config::TemplateSwitchConfig<
         Strategies::Alphabet,
         <Strategies as AlignmentStrategySelector>::Cost,
@@ -189,6 +189,7 @@ pub fn template_switch_distance_a_star_align<
     cost_limit: Option<Strategies::Cost>,
     memory_limit: Option<usize>,
     force_label_correcting: bool,
+    extend_beyond_range: bool,
     template_switch_count_memory: <Strategies::TemplateSwitchCount as TemplateSwitchCountStrategy>::Memory,
 ) -> AlignmentResult<template_switch_distance::AlignmentType, Strategies::Cost>
 where
@@ -227,16 +228,16 @@ where
     );
     info!("Main alignment finished");
 
-    info!("Extending template switches");
-    debug!("CIGAR before extending: {}", result.cigar());
-    let mut range = range;
-    let extension_steps =
-        result.extend_beyond_range_without_increasing_cost(reference, query, &mut range, config);
-    let range = range;
-    info!(
-        "Extended alignment {extension_steps} steps beyond the alignment range without increasing alignment costs"
-    );
-    info!("Alignment ranges after extension {range}");
+    if extend_beyond_range {
+        info!("Extending range");
+        debug!("CIGAR before extending: {}", result.cigar());
+        let extension_steps = result
+            .extend_beyond_range_without_increasing_cost(reference, query, &mut range, config);
+        info!(
+            "Extended alignment {extension_steps} steps beyond the alignment range without increasing alignment costs"
+        );
+        info!("Alignment ranges after extension {range}");
+    }
 
     info!("Extending template switches");
     result.compute_ts_equal_cost_ranges(reference, query, &range, config);

--- a/lib_tsalign/src/a_star_aligner/configurable_a_star_align.rs
+++ b/lib_tsalign/src/a_star_aligner/configurable_a_star_align.rs
@@ -95,6 +95,7 @@ struct QueryData<'a> {
     ranges: Option<AlignmentRange>,
     cost_limit: Option<u64>,
     memory_limit: Option<usize>,
+    extend_beyond_range: bool,
 }
 
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
@@ -190,6 +191,7 @@ impl<AlphabetType: Alphabet> Aligner<AlphabetType> {
         ranges: Option<AlignmentRange>,
         cost_limit: Option<u64>,
         memory_limit: Option<usize>,
+        extend_beyond_range: bool,
     ) -> AlignmentResult<AlignmentType, U64Cost> {
         let data = QueryData {
             reference_name,
@@ -199,6 +201,7 @@ impl<AlphabetType: Alphabet> Aligner<AlphabetType> {
             ranges,
             cost_limit,
             memory_limit,
+            extend_beyond_range,
         };
         self.align_select_min_length_strategy(data)
     }
@@ -302,6 +305,7 @@ impl<AlphabetType: Alphabet> Aligner<AlphabetType> {
             cost_limit,
             data.memory_limit,
             false,
+            data.extend_beyond_range,
             count_strategy_memory,
         )
     }
@@ -330,7 +334,8 @@ mod tests {
                 AlignmentCoordinates::new(33, 214)
             ).into(),
             None,
-            None);
+            None,
+        true);
         println!("{res:#?}");
         assert!(res.statistics().cost.is_sign_positive());
     }

--- a/lib_tsalign/src/costs/cost_function.rs
+++ b/lib_tsalign/src/costs/cost_function.rs
@@ -187,12 +187,9 @@ impl<SourceType: Bounded + Clone, Cost: Bounded + Zero + Eq> CostFunction<Source
         let start = if first.1.is_zero() {
             SourceType::min_value()
         } else if first.1 == Cost::max_value() {
-            if let Some(first) = function.next() {
-                if first.1.is_zero() {
-                    first.0.clone()
-                } else {
-                    return None;
-                }
+            let first = function.next()?;
+            if first.1.is_zero() {
+                first.0.clone()
             } else {
                 return None;
             }

--- a/lib_tsalign/src/tests.rs
+++ b/lib_tsalign/src/tests.rs
@@ -71,6 +71,7 @@ fn test_tsnax_disc1_473() {
         None,
         None,
         false,
+        true,
         (),
     );
     assert_eq!(
@@ -111,6 +112,7 @@ fn test_tsnax_disc1_473() {
         None,
         None,
         false,
+        true,
         (),
     );
     println!("{sample_alignment}");
@@ -141,6 +143,7 @@ fn test_tsnax_disc1_473() {
         None,
         None,
         false,
+        true,
         (),
     );
     println!("{sample_alignment}");
@@ -171,6 +174,7 @@ fn test_tsnax_disc1_473() {
         None,
         None,
         false,
+        true,
         (),
     );
     println!("{sample_alignment}");

--- a/python_bindings/src/lib.rs
+++ b/python_bindings/src/lib.rs
@@ -129,6 +129,7 @@ impl TSAligner {
             Some(ranges),
             cost_limit,
             memory_limit,
+            true,
         );
 
         match result {

--- a/tsalign/src/align.rs
+++ b/tsalign/src/align.rs
@@ -210,6 +210,11 @@ pub struct Cli {
     /// Template switch inners can still align to the full sequence.
     #[clap(long)]
     use_embedded_rq_ranges: bool,
+
+    /// If set, the aligner will not attempt to extend the alignment beyond the specified range
+    /// without increasing cost.
+    #[clap(long)]
+    dont_extend_beyond_range: bool,
 }
 
 #[derive(Args)]

--- a/tsalign/src/align/template_switch_distance_type_selectors.rs
+++ b/tsalign/src/align/template_switch_distance_type_selectors.rs
@@ -356,6 +356,7 @@ fn align_a_star_template_switch_distance_call<
         cli.cost_limit,
         cli.memory_limit,
         cli.force_label_correcting,
+        !cli.dont_extend_beyond_range,
         template_switch_count_memory,
     );
     info!("Finished aligning");


### PR DESCRIPTION
mini PR to give the user the option to not extend the ranges.
Motivation: When the ranges are extended (especially if by tens or hundreds of bases), the visualisation will not know what to "focus on". Therefore one might want to disable this.