### PR TITLE
fix: restore PyPI README by setting explicit readme path

### DIFF
--- a/python_bindings/pyproject.toml
+++ b/python_bindings/pyproject.toml
@@ -10,6 +10,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
+readme = "README.md"
 dynamic = ["version"]
 [tool.maturin]
 features = ["pyo3/extension-module"]


### PR DESCRIPTION
python-source = "python" broke maturin's auto-detection of README.md, which looked in python_bindings/python/ instead of python_bindings/.